### PR TITLE
Handle truncated episodes

### DIFF
--- a/train.py
+++ b/train.py
@@ -59,15 +59,15 @@ for e in range(episodes):
         action = mario.act(state)
         # Step through the environment; env.step returns (next_state, reward, done, truncated, info)
         next_state, reward, done, trunc, info = env.step(action)
-        # Store experience
-        mario.cache(state, next_state, action, reward, done)
+        # Store experience; mark terminal if done or truncated
+        mario.cache(state, next_state, action, reward, done or trunc)
         # Learn from experience
         q, loss = mario.learn()
         # Log metrics
         logger.log_step(reward, loss, q)
         state = next_state
         # End episode if game over or Mario reached the flag
-        if done or info.get("flag_get", False):
+        if done or trunc or info.get("flag_get", False):
             break
 
     logger.log_episode()

--- a/wrappers.py
+++ b/wrappers.py
@@ -18,7 +18,7 @@ class SkipFrame(gym.Wrapper):
             # Note: Gym 0.26+ returns (obs, reward, done, truncated, info)
             obs, reward, done, truncated, info = self.env.step(action)
             total_reward += reward
-            if done:
+            if done or truncated:
                 break
         return obs, total_reward, done, truncated, info
 


### PR DESCRIPTION
## Summary
- terminate training episodes on `truncated` as well as `done`
- record terminal transitions when either `done` or `truncated` occurs
- break out of frame skipping when `truncated` is signalled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c8454a9d88321b078fbedec3c3fdc